### PR TITLE
chore: upgrade gcp-metadata to 4.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
           - node: 8
             # overrides for node 8
             npm-version: ^6
-            lerna-extra-args: --ignore @opencensus/exporter-stackdriver
+            lerna-extra-args: --ignore @opencensus/exporter-stackdriver --ignore @opencensus/resource-util
     env:
       OPENCENSUS_MONGODB_TESTS: 1
       OPENCENSUS_REDIS_TESTS: 1

--- a/packages/opencensus-resource-util/package-lock.json
+++ b/packages/opencensus-resource-util/package-lock.json
@@ -9,7 +9,7 @@
 				"@types/nock": "^10.0.0",
 				"@types/node": "^10.17.60",
 				"codecov": "^3.6.2",
-				"gcp-metadata": "^3.0.0",
+				"gcp-metadata": "^4.3.0",
 				"gts": "^1.0.0",
 				"mocha": "^7.0.0",
 				"nock": "^10.0.0",
@@ -319,9 +319,9 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"node_modules/bignumber.js": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
 			"engines": {
 				"node": "*"
 			}
@@ -888,19 +888,6 @@
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
 		},
-		"node_modules/es6-promise": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-			"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
-		},
-		"node_modules/es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"dependencies": {
-				"es6-promise": "^4.0.3"
-			}
-		},
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1082,41 +1069,46 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"node_modules/gaxios": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.1.0.tgz",
-			"integrity": "sha512-Gtpb5sdQmb82sgVkT2GnS2n+Kx4dlFwbeMYcDlD395aEvsLCSQXJJcHt7oJ2LrGxDEAeiOkK79Zv2A8Pzt6CFg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
+			"integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
 			"dependencies": {
 				"abort-controller": "^3.0.0",
 				"extend": "^3.0.2",
-				"https-proxy-agent": "^3.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"is-stream": "^2.0.0",
 				"node-fetch": "^2.3.0"
 			},
 			"engines": {
-				"node": ">=8.10.0"
+				"node": ">=10"
 			}
 		},
-		"node_modules/gaxios/node_modules/agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+		"node_modules/gaxios/node_modules/debug": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 			"dependencies": {
-				"es6-promisify": "^5.0.0"
+				"ms": "2.1.2"
 			},
 			"engines": {
-				"node": ">= 4.0.0"
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/gaxios/node_modules/https-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 			"dependencies": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
+				"agent-base": "6",
+				"debug": "4"
 			},
 			"engines": {
-				"node": ">= 4.5.0"
+				"node": ">= 6"
 			}
 		},
 		"node_modules/gaxios/node_modules/is-stream": {
@@ -1127,16 +1119,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/gaxios/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
 		"node_modules/gcp-metadata": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.2.2.tgz",
-			"integrity": "sha512-vR7kcJMCYJG/mYWp/a1OszdOqnLB/XW1GorWW1hc1lWVNL26L497zypWb9cG0CYDQ4Bl1Wk0+fSZFFjwJlTQgQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
+			"integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"gaxios": "^2.1.0",
-				"json-bigint": "^0.3.0"
+				"gaxios": "^4.0.0",
+				"json-bigint": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=8.10.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/get-caller-file": {
@@ -1884,11 +1882,11 @@
 			}
 		},
 		"node_modules/json-bigint": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
-			"integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
 			"dependencies": {
-				"bignumber.js": "^7.0.0"
+				"bignumber.js": "^9.0.0"
 			}
 		},
 		"node_modules/json-parse-better-errors": {
@@ -4389,9 +4387,9 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"bignumber.js": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
 		},
 		"binary-extensions": {
 			"version": "2.0.0",
@@ -4854,19 +4852,6 @@
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
 		},
-		"es6-promise": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-			"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
-		},
-		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"requires": {
-				"es6-promise": "^4.0.3"
-			}
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -5006,48 +4991,53 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"gaxios": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.1.0.tgz",
-			"integrity": "sha512-Gtpb5sdQmb82sgVkT2GnS2n+Kx4dlFwbeMYcDlD395aEvsLCSQXJJcHt7oJ2LrGxDEAeiOkK79Zv2A8Pzt6CFg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
+			"integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
 			"requires": {
 				"abort-controller": "^3.0.0",
 				"extend": "^3.0.2",
-				"https-proxy-agent": "^3.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"is-stream": "^2.0.0",
 				"node-fetch": "^2.3.0"
 			},
 			"dependencies": {
-				"agent-base": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"requires": {
-						"es6-promisify": "^5.0.0"
+						"ms": "2.1.2"
 					}
 				},
 				"https-proxy-agent": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-					"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 					"requires": {
-						"agent-base": "^4.3.0",
-						"debug": "^3.1.0"
+						"agent-base": "6",
+						"debug": "4"
 					}
 				},
 				"is-stream": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
 					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
 		"gcp-metadata": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.2.2.tgz",
-			"integrity": "sha512-vR7kcJMCYJG/mYWp/a1OszdOqnLB/XW1GorWW1hc1lWVNL26L497zypWb9cG0CYDQ4Bl1Wk0+fSZFFjwJlTQgQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
+			"integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
 			"requires": {
-				"gaxios": "^2.1.0",
-				"json-bigint": "^0.3.0"
+				"gaxios": "^4.0.0",
+				"json-bigint": "^1.0.0"
 			}
 		},
 		"get-caller-file": {
@@ -5608,11 +5598,11 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-bigint": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
-			"integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
 			"requires": {
-				"bignumber.js": "^7.0.0"
+				"bignumber.js": "^9.0.0"
 			}
 		},
 		"json-parse-better-errors": {

--- a/packages/opencensus-resource-util/package.json
+++ b/packages/opencensus-resource-util/package.json
@@ -24,7 +24,7 @@
   "author": "OpenCensus Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "files": [
     "build/src/**/*.js",
@@ -63,6 +63,6 @@
   },
   "dependencies": {
     "@opencensus/core": "^0.0.22",
-    "gcp-metadata": "^3.0.0"
+    "gcp-metadata": "^4.3.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: drops support for node 8 in `@opencensus/resource-util` package. This is OK because the only dependent is the stackdriver exporter which already dropped it.